### PR TITLE
Create Risk Threshholds

### DIFF
--- a/Risk Threshholds
+++ b/Risk Threshholds
@@ -1,0 +1,24 @@
+using System;
+
+namespace SSA_Final.Services
+{
+    public class RiskClassificationService
+    {
+        public string GetRiskLevel(int score)
+        {
+            if (score < 0 || score > 100)
+                return "Unknown";
+
+            if (score <= 24)
+                return "Low";
+
+            if (score <= 49)
+                return "Medium";
+
+            if (score <= 74)
+                return "High";
+
+            return "Critical";
+        }
+    }
+}


### PR DESCRIPTION
Added risk score classification service to map numeric scores (0–100) into categories: Low, Medium, High, and Critical.

This supports clearer interpretation of phishing risk in scan results.